### PR TITLE
Fix typo bug

### DIFF
--- a/test/test_heading.cpp
+++ b/test/test_heading.cpp
@@ -195,7 +195,7 @@ TEST_F(TestHeading, ArithmeticOperators)
   C_1 += Heading(4 * M_PIl);
   EXPECT_DOUBLE_EQ(C_1.angle(), heading_1l);
 
-  C_1 = Heading(heading);
+  C_1 = Heading(theta_);
   EXPECT_TRUE(C_1 == C_1);
   EXPECT_FALSE(C_1 != C_1);
 


### PR DESCRIPTION
- The merge failed to replace `heading` with `theta_` in one of the
tests
- Closes #81