### PR TITLE
41-dead-reckon

### DIFF
--- a/include/turtle_nav_cpp/dead_reckon_estimator.hpp
+++ b/include/turtle_nav_cpp/dead_reckon_estimator.hpp
@@ -67,6 +67,19 @@ private:
    */
   void EstPosePublisher(const PoseWithCovarianceStamped & pose_with_cov_stamped) const;
 
+  /**
+   * @brief Dead-reckoning algorithm running on a timer
+   *
+   * @details When this function is called (by the timer), it checks the velocity queue and does the
+   *          following:
+   *          - If the queue is empty, then publish the latest stored pose (i.e., the robot didn't
+   *            move since the last pose)
+   *          - Otherwise, multiply out all previous poses and velocities similar to IMU
+   *            pre-integration
+   *          - Publish the estimated pose through the estimated pose publisher
+   */
+  void TimedDeadReckoning();
+
 private:
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // -- Topics to subscribe/publish to
@@ -105,6 +118,9 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr est_pose_publisher_{
     nullptr};
 
+  // Timer for estimated pose publisher
+  rclcpp::TimerBase::SharedPtr est_pose_publish_timer_;
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // -- Other vars
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -115,9 +131,6 @@ private:
   // TODO(aalbaali): To be replaced with a basic type (pose and covaraince)
   // Latest estimated pose
   PoseWithCovarianceStamped latest_est_pose_msg_;
-
-  // Latest estimated pose using the custom pose object
-  nav_utils::Pose latest_est_pose_;
 
   // History of cmd_vel messages
   std::queue<TwistWithCovarianceStamped> cmd_vel_history_;

--- a/include/turtle_nav_cpp/eigen_utils.hpp
+++ b/include/turtle_nav_cpp/eigen_utils.hpp
@@ -9,9 +9,6 @@
 #ifndef TURTLE_NAV_CPP_EIGEN_UTILS_HPP_
 #define TURTLE_NAV_CPP_EIGEN_UTILS_HPP_
 
-// Functions to add
-// - Converting heading to quaternion (one for tf2 and another for geometry_msgs)
-
 #include <Eigen/Dense>
 #include <array>
 #include <vector>

--- a/include/turtle_nav_cpp/nav_utils.hpp
+++ b/include/turtle_nav_cpp/nav_utils.hpp
@@ -10,16 +10,24 @@
 
 #include <Eigen/Dense>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <queue>
+#include <rclcpp/time.hpp>
 #include <turtlesim/msg/pose.hpp>
 
 #include "turtle_nav_cpp/heading.hpp"
 #include "turtle_nav_cpp/math_utils.hpp"
+#include "turtle_nav_cpp/pose.hpp"
 
 namespace turtle_nav_cpp
 {
 namespace nav_utils
 {
+using geometry_msgs::msg::PoseWithCovarianceStamped;
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+
 /**
  * @brief 2D Pose indices in 3D pose
  *
@@ -115,6 +123,24 @@ turtlesim::msg::Pose PoseMsgToTurtlePose(const geometry_msgs::msg::Pose & pose);
  * @return geometry_msgs::msg::Pose ROS geometry msg pose
  */
 geometry_msgs::msg::Pose TurtlePoseToPoseMsg(const turtlesim::msg::Pose & pose);
+
+//==================================================================================================
+// Filtering
+//==================================================================================================
+
+// TODO(aalbaali): Test this function
+/**
+ * @brief Accumulate odometry data using SE(2) process model (similar to IMU pre-integration)
+ *
+ * @param[in] query_at  Time to query (or predict) the pose
+ * @param[in] initial_pose Initial pose to start the dead-reckoning (should have a stamp before one
+ *                         of the velocity measurements)
+ * @param[in] vel_history History of velocities
+ * @return PoseWithCovarianceStamped Final pose
+ */
+PoseWithCovarianceStamped AccumOdom(
+  const rclcpp::Time & query_at, const PoseWithCovarianceStamped & initial_pose,
+  std::queue<TwistWithCovarianceStamped> & vel_history);
 
 }  // namespace nav_utils
 }  // namespace turtle_nav_cpp

--- a/include/turtle_nav_cpp/nav_utils.hpp
+++ b/include/turtle_nav_cpp/nav_utils.hpp
@@ -88,6 +88,14 @@ double QuaternionMsgToHeading(const geometry_msgs::msg::Quaternion & q);
  */
 geometry_msgs::msg::Quaternion HeadingToQuaternionMsg(double heading);
 
+/**
+ * @brief Extract angle from rotation matrix
+ *
+ * @param[in] rot SO(2) matrix
+ * @return double Angle
+ */
+double RotationMatrixToAngle(const Eigen::Matrix2d & rot);
+
 //==================================================================================================
 // Poses
 //==================================================================================================

--- a/launch/config/turtle_nav_filter.rviz
+++ b/launch/config/turtle_nav_filter.rviz
@@ -9,6 +9,8 @@ Panels:
         - /Grid1
         - /Grid1/Offset1
         - /TF1
+        - /PoseWithCovariance1/Covariance1
+        - /PoseWithCovariance1/Covariance1/Position1
       Splitter Ratio: 0.5
     Tree Height: 820
   - Class: rviz_common/Selection
@@ -71,6 +73,40 @@ Visualization Manager:
             true_turtle:
               {}
       Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz_default_plugins/PoseWithCovariance
+      Color: 85; 255; 255
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Head Length: 0.5
+      Head Radius: 0.10000000149011612
+      Name: PoseWithCovariance
+      Shaft Length: 1
+      Shaft Radius: 0.20000000298023224
+      Shape: Arrow
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /est_turtle/est_pose
       Value: true
   Enabled: true
   Global Options:

--- a/launch/config/turtle_nav_filter.yaml
+++ b/launch/config/turtle_nav_filter.yaml
@@ -70,7 +70,7 @@
     cmd_vel_meas_topic: /meas/wheel_encoder
 
     # ! Temporary: subscribe to this topic
-    true_pose_topoic: /true_turtle/pose
+    true_pose_topic: /true_turtle/pose
 
     # Pose to publish to
     est_pose_topic: /est_turtle/est_pose

--- a/launch/config/turtle_nav_filter.yaml
+++ b/launch/config/turtle_nav_filter.yaml
@@ -67,7 +67,7 @@
     initial_pose_topic: /initialpose
 
     # Velocity measurements topic
-    cmd_vel_meas_topic: /meas/cmd_vel
+    cmd_vel_meas_topic: /meas/wheel_encoder
 
     # ! Temporary: subscribe to this topic
     true_pose_topoic: /true_turtle/pose
@@ -75,5 +75,5 @@
     # Pose to publish to
     est_pose_topic: /est_turtle/est_pose
 
-    # Publishing frequency
-    publisher_est_pose_freq: 10   # Hz
+    # Estimated pose publishing frequency
+    est_pose_pub_freq: 0.5   # Hz

--- a/launch/config/turtle_nav_filter.yaml
+++ b/launch/config/turtle_nav_filter.yaml
@@ -76,4 +76,4 @@
     est_pose_topic: /est_turtle/est_pose
 
     # Estimated pose publishing frequency
-    est_pose_pub_freq: 0.5   # Hz
+    est_pose_pub_freq: 1.0   # Hz

--- a/src/nav_utils.cpp
+++ b/src/nav_utils.cpp
@@ -8,6 +8,8 @@
 
 #include "turtle_nav_cpp/nav_utils.hpp"
 
+#include <queue>
+
 #include "turtle_nav_cpp/math_utils.hpp"
 
 namespace turtle_nav_cpp
@@ -66,6 +68,98 @@ geometry_msgs::msg::Pose TurtlePoseToPoseMsg(const turtlesim::msg::Pose & pose)
   pose_msg.position.y = pose.y;
   pose_msg.orientation = Heading(pose.theta).QuaternionMsg();
   return pose_msg;
+}
+
+//==================================================================================================
+// Filtering
+//==================================================================================================
+
+PoseWithCovarianceStamped AccumOdom(
+  const rclcpp::Time & query_at, const PoseWithCovarianceStamped & initial_pose,
+  std::queue<TwistWithCovarianceStamped> & vel_history)
+{
+  rclcpp::Time initial_pose_time = initial_pose.header.stamp;
+
+  // Ensure query time is after initial pose
+  if (query_at < initial_pose_time) {
+    std::stringstream ss;
+    ss << "query time \033[93;1m" << query_at.seconds()
+       << "\033[0m is earlier than initial_pose time \033[93;1m" << initial_pose_time.seconds();
+    throw std::invalid_argument(ss.str());
+  }
+
+  // Need non-empty velocity history to dead-reckon
+  if (vel_history.size() == 0) {
+    PoseWithCovarianceStamped latest_pose = initial_pose;
+    latest_pose.header.stamp = query_at;
+    return latest_pose;
+  }
+
+  // Latest measurement (start from the earliest measurement)
+  TwistWithCovarianceStamped earliest_vel = vel_history.back();
+
+  // Flag to indicate that the pose is successfully predicted to the requested query time
+  // Note that this may happen before the velocity history queue is emptied
+  bool is_predicted_to_query_time = false;
+
+  // Latest pose, where it's assumed that the latest pose remains unchanged until the latest
+  // measurement comes in
+  PoseWithCovarianceStamped latest_pose = initial_pose;
+
+  // Deal with the case that query time is between initial_pose and the earliest velocity
+  // measurement, in which case the pose remains unchanged
+  if (query_at < earliest_vel.header.stamp) {
+    latest_pose.header.stamp = query_at;
+    return latest_pose;
+  }
+
+  // Predict poses until the last velocity time stamp
+  while (!vel_history.empty() && !is_predicted_to_query_time) {
+    earliest_vel = vel_history.back();
+    vel_history.pop();
+
+    // Query time to predict to
+    rclcpp::Time time_to_predict_to = earliest_vel.header.stamp;
+
+    // Deal with measurements earlier than latest pose
+    if (time_to_predict_to < latest_pose.header.stamp) {
+      continue;
+    }
+
+    // Use query time if it's earlier than the velocity time
+    if (query_at <= time_to_predict_to) {
+      time_to_predict_to = query_at;
+      is_predicted_to_query_time = true;
+    }
+
+    // Time difference between latest velocity and latest pose
+    auto duration_latest_pose_to_query_time = time_to_predict_to - latest_pose.header.stamp;
+
+    // * Ignore covariances for now
+    // Dead-reckon poses using SE(2) model
+    double dt = duration_latest_pose_to_query_time.seconds();
+    Pose T_km1 = latest_pose.pose.pose;
+    Vector2d linear_vel_km1 =
+      Vector2d(earliest_vel.twist.twist.linear.x, earliest_vel.twist.twist.linear.y);
+    double angular_vel_km1 = earliest_vel.twist.twist.angular.z;
+    Pose T_k = T_km1 * Pose(dt * linear_vel_km1, dt * angular_vel_km1);
+    latest_pose.pose.pose = T_k.PoseMsg();
+    latest_pose.header.stamp = time_to_predict_to;
+  }
+
+  // Now predict pose from latest pose to query time
+  if (!is_predicted_to_query_time) {
+    auto duration_latest_pose_to_query_time = query_at - latest_pose.header.stamp;
+    double dt = duration_latest_pose_to_query_time.seconds();
+    Pose T_km1 = latest_pose.pose.pose;
+    Vector2d linear_vel_km1{earliest_vel.twist.twist.linear.x, earliest_vel.twist.twist.linear.y};
+    double angular_vel_km1 = earliest_vel.twist.twist.angular.z;
+    Pose T_k = T_km1 * Pose(dt * linear_vel_km1, dt * angular_vel_km1);
+    latest_pose.pose.pose = T_k.PoseMsg();
+    latest_pose.header.stamp = query_at;
+  }
+
+  return latest_pose;
 }
 
 }  // namespace nav_utils

--- a/src/turtle_est_broadcaster.cpp
+++ b/src/turtle_est_broadcaster.cpp
@@ -169,11 +169,7 @@ void EstimatorBroadcaster::TeleportPose(const turtlesim::msg::Pose::SharedPtr ms
   request->set__y(msg->y + 1.0);
   request->set__theta(msg->theta);
 
-  auto result = teleporter_->async_send_request(request);
-
-  std::stringstream ss;
-  ss << "x: " << msg->x << ", y: " << msg->y << ", theta: " << msg->theta;
-  RCLCPP_INFO(this->get_logger(), ss.str());
+  teleporter_->async_send_request(request);
 }
 
 bool EstimatorBroadcaster::SpawnTurtle(

--- a/test/test_pose.cpp
+++ b/test/test_pose.cpp
@@ -194,8 +194,10 @@ TEST_F(TestPose, Operators)
 
   // Self compounding
   T *= Pose(5, 6, -0.1);
-  EXPECT_DOUBLE_EQ(T.x(), x_ + 5);
-  EXPECT_DOUBLE_EQ(T.y(), y_ + 6);
+  x_3 = cos(theta_) * 5 - sin(theta_) * 6 + x_;
+  y_3 = sin(theta_) * 5 + sin(theta_) * 6 + y_;
+  EXPECT_DOUBLE_EQ(T.x(), x_3);
+  EXPECT_DOUBLE_EQ(T.y(), y_3);
   EXPECT_DOUBLE_EQ(T.angle(), theta_ - 0.1);
 
   // Equality and non-equality operator


### PR DESCRIPTION
Closes #41

Few notes about dead-reckoning:
- To kick-off dead reckoning, set up the pose in RVIZ using the _2D Pose Estimate_ button
- Using a high-frequency publishing causes unexpected behaviour (aliasing?); the bug is reported in #90 
- The covariances are not propagated so they covariances visualized by rviz are _not_ accurate
- The dead-reckoning estimator does _not_ take care of the boundaries imposed by turtlesim.

![image](https://user-images.githubusercontent.com/36138453/160239134-e20b276f-e97b-4dcf-9e43-04c72ecf1372.png)
